### PR TITLE
[EPIC_0]  Реализация DI (Koin) для NetworkClient, репозиториев и ViewModel`s

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/common/constants/AppConstants.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/common/constants/AppConstants.kt
@@ -4,4 +4,6 @@ object AppConstants {
     const val NOT_AVAILABLE = "N/A"
     const val CLICK_DEBOUNCE_DELAY_MILLIS = 1000L
     const val SEARCH_DEBOUNCE_DELAY_MILLIS = 2000L
+    const val SHARED_PREFERENCES = "app_preferences"
+    const val BASE_URL = "https://api.hh.ru/"
 }

--- a/app/src/main/java/ru/practicum/android/diploma/di/AppModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/di/AppModule.kt
@@ -2,8 +2,24 @@ package ru.practicum.android.diploma.di
 
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
+import ru.practicum.android.diploma.country.presentation.viewmodel.CountryViewModel
+import ru.practicum.android.diploma.favorites.presentation.viewmodel.FavoritesViewModel
+import ru.practicum.android.diploma.filter.presentation.viewmodel.FilterViewModel
+import ru.practicum.android.diploma.industry.presentation.viewmodel.IndustryViewModel
+import ru.practicum.android.diploma.region.presentation.viewmodel.RegionViewModel
+import ru.practicum.android.diploma.search.presentation.viewmodel.SearchViewModel
 import ru.practicum.android.diploma.team.presentation.viewmodel.TeamViewModel
+import ru.practicum.android.diploma.vacancy.presentation.viewmodel.VacancyViewModel
+import ru.practicum.android.diploma.workplace.presentation.viewmodel.WorkplaceViewModel
 
 val appModule = module {
+    viewModelOf(::CountryViewModel)
+    viewModelOf(::FavoritesViewModel)
+    viewModelOf(::FilterViewModel)
+    viewModelOf(::IndustryViewModel)
+    viewModelOf(::RegionViewModel)
+    viewModelOf(::SearchViewModel)
     viewModelOf(::TeamViewModel)
+    viewModelOf(::VacancyViewModel)
+    viewModelOf(::WorkplaceViewModel)
 }

--- a/app/src/main/java/ru/practicum/android/diploma/di/DataModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/di/DataModule.kt
@@ -7,5 +7,6 @@ import ru.practicum.android.diploma.team.data.repository.DevTeamRepositoryImpl
 import ru.practicum.android.diploma.team.domain.repository.DevTeamRepository
 
 val dataModule = module {
+    /** Developers Team Repository */
     factoryOf(::DevTeamRepositoryImpl) { bind<DevTeamRepository>() }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/di/SourceModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/di/SourceModule.kt
@@ -1,11 +1,62 @@
 package ru.practicum.android.diploma.di
 
+import android.content.Context
+import com.google.gson.Gson
+import okhttp3.OkHttpClient
+import org.koin.android.ext.koin.androidApplication
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import ru.practicum.android.diploma.common.constants.AppConstants.BASE_URL
+import ru.practicum.android.diploma.common.constants.AppConstants.SHARED_PREFERENCES
+import ru.practicum.android.diploma.search.data.source.remote.HHApiHeadersInterceptor
+import ru.practicum.android.diploma.search.data.source.remote.HHApiService
+import ru.practicum.android.diploma.search.data.source.remote.NetworkClient
+import ru.practicum.android.diploma.search.data.source.remote.RetrofitClient
 import ru.practicum.android.diploma.team.data.source.DataSource
 import ru.practicum.android.diploma.team.data.source.local.LocalDataSource
 
+/**
+ * Модуль зависимостей приложения, предоставляющий:
+ * - Работу с сетью (Retrofit, OkHttp)
+ * - Локальное хранилище (SharedPreferences)
+ * - Конвертацию данных (Gson)
+ */
 val sourceModule = module {
+    // Настройки SharedPreferences для хранения простых данных
+    single {
+        androidApplication().getSharedPreferences(
+            SHARED_PREFERENCES, // Имя файла настроек
+            Context.MODE_PRIVATE // Режим доступа (только для этого приложения)
+        )
+    }
+
+    // HTTP-клиент с кастомным интерцептором для добавления заголовков
+    single {
+        OkHttpClient.Builder()
+            .addInterceptor(HHApiHeadersInterceptor()) // Добавляем интерцептор для API hh.ru
+            .build()
+    }
+
+    // Retrofit-клиент для работы с API hh.ru
+    single<HHApiService> {
+        Retrofit.Builder()
+            .baseUrl(BASE_URL) // Базовый URL API
+            .client(get<OkHttpClient>()) // Используем настроенный OkHttpClient
+            .addConverterFactory(GsonConverterFactory.create()) // Конвертер JSON в объекты
+            .build()
+            .create(HHApiService::class.java) // Создаем реализацию API-интерфейса
+    }
+
+    // Gson для сериализации/десериализации JSON
+    singleOf(::Gson)
+
+    // Сетевой клиент приложения (реализация через Retrofit)
+    singleOf(::RetrofitClient) { bind<NetworkClient>() }
+
+    // Локальное хранилище данных о команде разработчиков
     factoryOf(::LocalDataSource) { bind<DataSource>() }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/search/data/source/remote/RetrofitClient.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/search/data/source/remote/RetrofitClient.kt
@@ -79,8 +79,6 @@ class RetrofitClient(private val hhApiService: HHApiService, private val network
     }
 
     companion object {
-        const val BASE_URL = "https://api.hh.ru/"
-
         const val OK = 200
         const val BAD_REQUEST = 400
         const val UNAUTHORIZED = 401


### PR DESCRIPTION
### Задача:
- Настроить DI-модули (Koin) для `NetworkClient`, репозиториев и  и ViewModel`s

### Изменения:
✅ Добавлен `sourceModule` с настройкой:
   - `Retrofit`
   - `OkHttpClient` 
   - `NetworkClient`

✅ Добавлен `dataModule` с внедрением репозиториев

✅ Добавлен `appModule` с внедрением ViewModel`s

### Особые заметки:
- `NetworkClient` привязан к `Retrofit`-реализации
- Репозитории используют `DataSource` через DI
- Все зависимости корректно резолвятся в тестовой среде